### PR TITLE
docs: fix RAG retrieval typos

### DIFF
--- a/llms/rag.md
+++ b/llms/rag.md
@@ -179,7 +179,7 @@ Challenges with naive RAG - two types
 - quality - hallucination, accuracy
 - non-quality - latency, cost
 
-Quality - bad retrival
+Quality - bad retrieval
 - low precision - not all chunks are relevant -> hallucination or `lost in the middle` problem
 - low recall - not all relevant chunks are retrieved
 - outdated information
@@ -201,7 +201,7 @@ How to measure performance / evaluation
 
 Evaluate of 50 data points
 
-Retrival evaluation
+Retrieval evaluation
 - quality of retrieved chunks
 - want to return most relevant chunks
 - if you can compare with ground truth, can compare predicted against ground truth
@@ -229,9 +229,9 @@ Simple
 
 Advanced
 - reranking
-- recursive retrival
+- recursive retrieval
 - embedding table
-- small to big retrival
+- small to big retrieval
 
 Fine tuning
 - embeddings


### PR DESCRIPTION
## Problem
The RAG notes spell `retrieval` as `retrival` in a few headings/list items.

## Solution
Correct the spelling in the RAG documentation.

## Validation
- `git diff --check`

## Confidence
85/100 — docs-only typo fix in the RAG notes.